### PR TITLE
Plugin generator command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This extension is adding autocomplete for lua scripts on Swiftly - Counter Strike 2.
 
 This extension is using the [Lua Extension](https://marketplace.visualstudio.com/items?itemName=sumneko.lua) from Sumneko for adding autocomplete.
+
+In addition to autocomplete, this extension also allows you to quickly generate a new plugin structure. You can do this by opening the Command Palette (Ctrl+Shift+P or Cmd+Shift+P on macOS) and running the SwiftlyCS2: Generate Plugin command. This will create a basic plugin template that you can start customizing immediately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swiftly---cs2-autocomplete",
-  "version": "1.0.13",
+  "version": "1.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swiftly---cs2-autocomplete",
-      "version": "1.0.13",
+      "version": "1.0.22",
       "devDependencies": {
         "@types/mocha": "^10.0.7",
         "@types/node": "20.x",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "activationEvents": [
     "onStartupFinished"
+    
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -33,6 +34,10 @@
         "command": "swiftly---cs2-autocomplete.enableAnnotations",
         "title": "Enable Annotations",
         "category": "SwiftlyCS2 - Lua Autocomplete"
+      },
+      {
+        "command": "swiftly---cs2-autocomplete.commands.generatePlugin",
+        "title": "SwiftlyCS2 - Generate Plugin"
       }
     ]
   },

--- a/src/PluginGenerator.ts
+++ b/src/PluginGenerator.ts
@@ -1,0 +1,130 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export class PluginGenerator {
+    private rootPath: string;
+    private pluginName: string;
+    private pluginAuthor: string;
+    private pluginVersion: string;
+    private pluginWebsite: string | undefined; // Optional
+
+    constructor(rootPath: string, pluginName: string, pluginAuthor: string, pluginVersion: string, pluginWebsite?: string) {
+        this.rootPath = rootPath;
+        this.pluginName = pluginName;
+        this.pluginAuthor = pluginAuthor;
+        this.pluginVersion = pluginVersion;
+        this.pluginWebsite = pluginWebsite;
+    }
+
+    public generateStructure(manifestFileName: string, createFolder: boolean): void {
+        const pluginPath = createFolder ? path.join(this.rootPath, this.pluginName) : this.rootPath;
+
+        const files: { [key: string]: string } = {
+            [`${manifestFileName}.lua`]: this.getLuaPluginInfo()
+        };
+
+        if (createFolder) {
+            fs.mkdirSync(pluginPath, { recursive: true });
+        }
+
+        Object.keys(files).forEach(file => {
+            const filePath = path.join(pluginPath, file);
+            fs.writeFileSync(filePath, files[file]);
+        });
+    }
+
+    public getLuaPluginInfo(): string {
+        return `function GetPluginAuthor()
+    return "${this.pluginAuthor}"
+end
+function GetPluginVersion()
+    return "${this.pluginVersion}"
+end
+function GetPluginName()
+    return "${this.pluginName}"
+end
+function GetPluginWebsite()
+    return "${this.pluginWebsite}"
+end
+`;
+    }
+}
+
+export function registerPluginGeneratorCommand(context: vscode.ExtensionContext) {
+    let disposable = vscode.commands.registerCommand('swiftly---cs2-autocomplete.commands.generatePlugin', async () => {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+
+        const pluginName = await vscode.window.showInputBox({ prompt: 'Enter the plugin name' });
+        if (!pluginName) {
+            vscode.window.showErrorMessage('Plugin name is required.');
+            return;
+        }
+
+        const pluginAuthor = await vscode.window.showInputBox({ prompt: 'Enter the plugin author' });
+        if (!pluginAuthor) {
+            vscode.window.showErrorMessage('Plugin author is required.');
+            return;
+        }
+
+        const pluginVersion = await vscode.window.showInputBox({ prompt: 'Enter the plugin version', value: 'v1.0.0' });
+        if (!pluginVersion) {
+            vscode.window.showErrorMessage('Plugin version is required.');
+            return;
+        }
+
+        const pluginWebsite = await vscode.window.showInputBox({ prompt: 'Enter the plugin website (optional)' });
+
+        const pluginManifestFile = await vscode.window.showInputBox({ prompt: 'Enter the name of the main plugin file', value: 'manifest' });
+        if (!pluginManifestFile) {
+            vscode.window.showErrorMessage('Plugin main file name is required.');
+            return;
+        }
+
+        if (workspaceFolders && workspaceFolders.length > 0) {
+            // Workspace is open, create folder in the existing workspace
+            const rootPath = workspaceFolders[0].uri.fsPath;
+            const pluginPath = path.join(rootPath, pluginName);
+
+            // Ensure plugin folder does not already exist
+            if (fs.existsSync(pluginPath)) {
+                vscode.window.showErrorMessage(`Folder "${pluginName}" already exists in the workspace.`);
+                return;
+            }
+
+            // Generate plugin structure in the workspace folder
+            const generator = new PluginGenerator(rootPath, pluginName, pluginAuthor, pluginVersion, pluginWebsite);
+            generator.generateStructure(pluginManifestFile, true);
+            vscode.window.showInformationMessage(`Plugin "${pluginName}" generated successfully.`);
+        } else {
+            const newWorkspaceUri = await vscode.window.showOpenDialog({
+                openLabel: 'Select folder for new plugin',
+                canSelectFiles: false,
+                canSelectFolders: true,
+                canSelectMany: false
+            });
+
+            if (newWorkspaceUri && newWorkspaceUri.length > 0) {
+                const newWorkspacePath = newWorkspaceUri[0].fsPath;
+                const workspaceFolderPath = path.join(newWorkspacePath, pluginName);
+
+                // Create new workspace folder
+                if (!fs.existsSync(workspaceFolderPath)) {
+                    fs.mkdirSync(workspaceFolderPath, { recursive: true });
+                }
+
+                // Create the manifest file in the new workspace
+                const generator = new PluginGenerator(workspaceFolderPath, pluginName, pluginAuthor, pluginVersion, pluginWebsite);
+                generator.generateStructure(pluginManifestFile, false);
+
+                // Open the new workspace
+                const workspaceUri = vscode.Uri.file(workspaceFolderPath);
+                vscode.commands.executeCommand('vscode.openFolder', workspaceUri, false);
+            } else {
+                vscode.window.showErrorMessage('No folder selected. Aborting.');
+            }
+        }
+    });
+
+    context.subscriptions.push(disposable);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { registerPluginGeneratorCommand } from './PluginGenerator';
 
 function setExternalLibrary(folder: string, enable: boolean) {
 	const extensionId = "swiftlycs2.swiftly---cs2-autocomplete"; // this id is case sensitive
@@ -50,6 +51,8 @@ export function activate(context: vscode.ExtensionContext) {
 		setExternalLibrary("EmmyLua", true);
 		context.globalState.update("disableExternalLib", 0);
 	}));
+
+	registerPluginGeneratorCommand(context);
 
 }
 


### PR DESCRIPTION
### Pull Request Description

#### Summary

This pull request introduces a new feature to the SwiftlyCS2 extension: the ability to generate a new plugin structure.

#### Changes Made

- Added a new command `SwiftlyCS2 - Generate Plugin` to the Command Palette (accessible via `Ctrl+Shift+P` or `Cmd+Shift+P` on macOS).
- This command allows users to quickly create a basic plugin template with a pre-defined structure for Lua scripts.
- The user is prompted to provide a name for the main plugin file (instead of a fixed `manifest.lua`), which will be included in the generated plugin structure.
- If no workspace is open, the command will create a new folder with the plugin name and set it as the workspace. The main plugin file will be placed in this folder.

#### How It Works

In addition to providing autocomplete functionality for Lua scripts, this extension now supports plugin generation. Users can:
1. Open the Command Palette with `Ctrl+Shift+P` or `Cmd+Shift+P`.
2. Run the `SwiftlyCS2 - Generate Plugin` command.
3. Follow the prompts to specify the plugin name, author, version, and website (optional), and to provide a name for the main plugin file.
4. If a workspace is open, a new folder with the plugin name will be created within the workspace, and the main plugin file will be added to this folder.
5. If no workspace is open, a new folder with the plugin name will be created, and a new workspace will be set with this folder as the root. The main plugin file will be placed in this newly created folder.

This feature streamlines the process of setting up new plugins and ensures that users have a consistent starting point for their development, whether or not a workspace is currently open.